### PR TITLE
Implement new design prompts

### DIFF
--- a/css/_layout.css
+++ b/css/_layout.css
@@ -5,8 +5,8 @@
   padding-inline: var(--gutter);
 }
 
-section.section {
-  padding-block: clamp(6rem,10vh,12rem);
+.section {
+  padding-block: clamp(4rem, 10vw, 8rem);
 }
 
 .section-title {

--- a/css/_reset.css
+++ b/css/_reset.css
@@ -5,7 +5,7 @@
 html,
 body {
   margin: 0;
-  font-family: Inter, sans-serif;
+  font-family: 'SF Pro Display', Inter, sans-serif;
   background: var(--bg);
   color: var(--text-dark);
   overflow-x: hidden;

--- a/css/_variables.css
+++ b/css/_variables.css
@@ -3,7 +3,8 @@
   --bg-elev: #fff;
   --brand-blue: #0071e3;
   --brand-blue-dark: #3659d3;
-  --h1: clamp(3rem,7vw,96px);
+  --h1: clamp(3.25rem,9vw,5.5rem);
+  --font-body: 'SF Pro Display', Inter, Arial, sans-serif;
   --muted: #f5f5f7;
   --radius: 28px;
   --container: 80rem;

--- a/css/components.css
+++ b/css/components.css
@@ -147,9 +147,12 @@ nav ul {
 .mobile-menu::-webkit-scrollbar { display: none; }
 .mobile-menu.open { transform: translateX(0); opacity: 1; }
 
-.hero-copy { }
+.hero-copy {
+  grid-column: 2 / 7;
+}
 
 .hero-img {
+  grid-column: 8 / 14;
   aspect-ratio: 16/10;
   border-radius: 32px;
   box-shadow: 0 8px 24px rgb(0 0 0 / 8%);
@@ -158,16 +161,16 @@ nav ul {
 }
 
 .card-project {
-  background: var(--bg-elev);
-  border-radius: 28px;
+  border-radius: var(--radius);
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   overflow: hidden;
-  box-shadow: var(--shadow-level1);
-  transition: 0.25s;
 }
 
 .card-project:hover {
-  box-shadow: 0 16px 32px rgb(0 0 0 / 15%);
-  transform: translateY(-4px);
+  transform: translateY(-6px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.14);
 }
 
 .card-project img,
@@ -221,7 +224,8 @@ nav ul {
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 3rem;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+  padding-inline: clamp(1rem, 4vw, 3rem);
 }
 
 @media (width <= 736px) {
@@ -366,7 +370,7 @@ nav ul {
 
 .faq-item {
   background: var(--bg-elev);
-  border-radius: 14px;
+  border-radius: 24px;
   box-shadow: var(--shadow-level1);
   overflow: hidden;
   border: 1px solid rgb(0 0 0 / 4%);
@@ -379,12 +383,14 @@ nav ul {
 
 .faq-item summary {
   cursor: pointer;
-  padding: 1.2rem 0;
+  padding-inline: 1.6rem;
+  font-size: 1.1rem;
   font-weight: 600;
   list-style: none;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  background: #fff;
 }
 .faq-item summary::-webkit-details-marker { display: none; }
 .faq-item summary::after { content: "›"; float: right; transition: transform 0.3s; }
@@ -405,9 +411,12 @@ nav ul {
 header {
   position: sticky;
   top: 0;
+  backdrop-filter: saturate(180%) blur(20px);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+  transition: background 0.3s ease;
   z-index: 999;
   height: 54px;
-  background: #fff;
   border: none;
 }
 
@@ -417,10 +426,11 @@ header {
 
 .hero {
   position: relative;
-  padding-block: 12vh;
   display: grid;
-  gap: 3.2rem;
+  grid-template-columns: minmax(1rem, 1fr) repeat(12, 1fr) minmax(1rem, 1fr);
   align-items: center;
+  min-height: 88vh;
+  padding-block: clamp(6rem, 14vw, 10rem);
 }
 
 .hero::before {
@@ -434,11 +444,12 @@ header {
 }
 
 h1 {
-  font-size: clamp(48px, 7vw, 96px);
+  font-size: var(--h1);
   line-height: 1.15;
   max-width: 18ch;
+  letter-spacing: -0.02em;
   font-weight: 800;
-  margin-bottom: 1.4rem;
+  margin: 0 0 2rem;
 }
 
 .hero-sub {
@@ -660,9 +671,11 @@ body.modal-open {
 }
 
 footer {
-  padding: 3rem 0;
+  display: grid;
+  place-items: center;
+  gap: 2rem;
+  padding-block: 4rem;
   background: #f5f5f7;
-  text-align: center;
 }
 
 .footer-info {
@@ -678,6 +691,21 @@ footer {
   display: flex;
   gap: 1rem;
   font-size: 0.75rem;
+}
+
+#toTop {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #0071e3;
+  color: #fff;
+  font-size: 1.25rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
 }
 
 #toast {
@@ -750,13 +778,28 @@ footer {
   }
 }
 
-img.placeholder,
-img[src*="placeholder"],
+@keyframes shine {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
 .placeholder {
-  aspect-ratio: 16/9;
-  background: #e6e9ee
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='135'%3E%3Crect width='240' height='135' fill='%23dfe3ea'/%3E%3Ctext x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%239aa3b3' font-size='16' font-family='Inter'%3Eimage%3C/text%3E%3C/svg%3E")
-    center/70% no-repeat;
+  background: #e9ebee;
+  position: relative;
+  overflow: hidden;
+}
+
+.placeholder::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.6) 50%, transparent 100%);
+  background-size: 200% 100%;
+  animation: shine 1.2s infinite;
 }
 
 @media print {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       media="print"
       onload="this.media='all'"
     />
+    <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/sf-pro-display" />
 
     <!-- Styles -->
     <link rel="stylesheet" href="styles.css" />
@@ -386,6 +387,7 @@
         <a href="#top">Retour haut ↑</a>
       </div>
     </footer>
+    <button id="toTop" aria-label="Haut de page">↑</button>
 
     <!-- Contact Modal -->
     <div

--- a/main.js
+++ b/main.js
@@ -211,6 +211,11 @@ document.getElementById("contactForm").addEventListener("submit", (e) => {
 /* Year */
 document.getElementById("year").textContent = new Date().getFullYear();
 
+/* To Top button */
+const toTop = document.getElementById("toTop");
+toTop.onclick = () =>
+  window.scrollTo({ top: 0, behavior: "smooth" });
+
 /* FAQ exclusive open */
 document.querySelectorAll('.faq-item').forEach(d => {
   d.addEventListener('toggle', e => {


### PR DESCRIPTION
## Summary
- load SF Pro Display font
- tweak header to be blurred and sticky
- restructure hero section layout
- adjust headline size and spacing
- apply Apple-style cards and new projects grid rhythm
- add shimmer placeholder animation
- update general section spacing
- refine FAQ accordion look
- redesign footer and add "to top" button

## Testing
- `npx stylelint "**/*.css"` *(fails: package installation canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6883a18a5a9883338788bce0a587f3f3